### PR TITLE
feat: filter files exceeding API size limits before sending review

### DIFF
--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -206,13 +206,15 @@ class ReviewService {
   private filterFiles(files: FileContent[]): FileContent[] {
     const skipped: string[] = [];
     const filtered = files.filter(f => {
-      if (f.diff.length > MAX_DIFF_SIZE) {
-        const sizeKB = Math.round(f.diff.length / 1024);
+      const diffBytes = Buffer.byteLength(f.diff, 'utf8');
+      const contentBytes = Buffer.byteLength(f.content, 'utf8');
+      if (diffBytes > MAX_DIFF_SIZE) {
+        const sizeKB = Math.round(diffBytes / 1024);
         skipped.push(`  - ${f.path} (diff: ${sizeKB}KB, max: ${MAX_DIFF_SIZE / 1024}KB)`);
         return false;
       }
-      if (f.content.length > MAX_CONTENT_SIZE) {
-        const sizeMB = (f.content.length / (1024 * 1024)).toFixed(1);
+      if (contentBytes > MAX_CONTENT_SIZE) {
+        const sizeMB = (contentBytes / (1024 * 1024)).toFixed(1);
         skipped.push(`  - ${f.path} (content: ${sizeMB}MB, max: ${MAX_CONTENT_SIZE / (1024 * 1024)}MB)`);
         return false;
       }


### PR DESCRIPTION
Add client-side validation to skip files with diff > 500KB, content > 2MB, and cap at 100 files per request to prevent API 400 errors.

---

<!-- kody-pr-summary:start -->
This pull request implements client-side filtering for files before they are sent for code review, ensuring that only files within defined API limits are processed.

The following limits are now enforced:
*   **Maximum Diff Size:** Files with a diff exceeding 500KB will be skipped.
*   **Maximum File Content Size:** Files with full content exceeding 2MB will be skipped.
*   **Maximum Number of Files:** If more than 100 files remain after individual size filtering, only the first 100 files will be sent for review.

When files are skipped due to size limits or if the total file count is truncated, a warning message is displayed in the console, providing feedback on which files were affected and why. This helps prevent sending excessively large payloads to the review API and improves overall reliability.
<!-- kody-pr-summary:end -->