### PR TITLE
Feat/centralized config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kodus/cli",
-    "version": "0.4.12",
+    "version": "0.4.13",
     "description": "Kodus CLI - AI-powered code review from your terminal",
     "type": "module",
     "bin": {

--- a/skills/kodus-kody-rules/SKILL.md
+++ b/skills/kodus-kody-rules/SKILL.md
@@ -15,6 +15,16 @@ Manage Kody Rules through Kodus CLI only. Do not suggest creating rule files man
 
 ALWAYS Use `kodus rules` subcommands for all create, update, and view operations. All these rules are ALWAYS managed by the `kodus rules` command from the CLI. Do NOT suggest creating files or storing rules in any other way. When the user wants to create, update or view Kody Rules, utilize the `kodus rules` command with the appropriate subcommands and options as outlined in the instructions files.
 
+## Centralized Config Convention
+
+When centralized config is enabled for the selected team/repository scope, `kodus rules create` and `kodus rules update` may return centralized PR metadata instead of directly created/updated rule records.
+
+- Treat this as success, not failure.
+- Prioritize reporting `prUrl` (and `prNumber` when available).
+- Explain that the change is pending until the centralized PR is merged and synced.
+- Do not claim a rule was directly persisted when the result is centralized PR mode.
+- When output includes both direct results and centralized PR metadata, prefer communicating the centralized PR outcome.
+
 ## Shared Workflow
 
 1. Confirm the requested action:

--- a/skills/kodus-kody-rules/instructions/create-kody-rule.md
+++ b/skills/kodus-kody-rules/instructions/create-kody-rule.md
@@ -33,6 +33,16 @@ If `--repo-id` is omitted, the default repository id is `global`.
 
 6. **Communicate the new Kody Rule**: Inform the user about the new Kody Rule and how it will be applied in future code generation.
 
+## Centralized Config Behavior
+
+When centralized config is enabled, creating a rule may return a centralized PR result instead of a directly persisted rule.
+
+In this case:
+
+1. Report the PR URL (and PR number if present).
+2. State that the rule is pending and will be applied after PR merge and sync.
+3. Do not present the rule as already created in the database.
+
 ## Guidelines for Creating a Kody Rule
 
 1. **Identify the Purpose**: Clearly define what the Kody Rule is intended to achieve. Is it meant to enforce a coding style, ensure best practices, or address a specific use case?

--- a/skills/kodus-kody-rules/instructions/update-kody-rule.md
+++ b/skills/kodus-kody-rules/instructions/update-kody-rule.md
@@ -40,6 +40,16 @@ If `--repo-id` is omitted, the default repository id is `global`.
 
 8. **Communicate the updated Kody Rule**: Inform the user about the updated Kody Rule and how the changes will affect future code generation.
 
+## Centralized Config Behavior
+
+When centralized config is enabled, updating a rule may return a centralized PR result instead of an immediate in-database update.
+
+In this case:
+
+1. Report the PR URL (and PR number if present).
+2. State that the update is pending and will be applied after PR merge and sync.
+3. Do not claim the rule content was already updated in the database.
+
 ## Guidelines for Updating a Kody Rule
 
 1. **Identify the Changes**: Clearly define what changes are being made to the existing Kody Rule. Are you modifying the rule's behavior, scope, severity, or other attributes?

--- a/skills/kodus-kody-rules/instructions/view-kody-rules.md
+++ b/skills/kodus-kody-rules/instructions/view-kody-rules.md
@@ -44,6 +44,16 @@ Do not alter the content of the rules; display them as they are retrieved to ens
 
 5. **Answer Follow-up Questions**: Be prepared to answer any follow-up questions the user may have about the Kody Rules, such as how to create or update rules, or how specific rules affect code generation.
 
+## Centralized Config Context
+
+When centralized config is enabled, rules may have pending centralized changes.
+
+When relevant, highlight:
+
+- centralized path (`centralizedConfig.path`)
+- centralized status (`pending_add`, `pending_edit`, `pending_delete`, `synced`)
+- whether a previously returned PR URL indicates pending application until merge and sync
+
 ## Guidelines for Viewing Kody Rules
 
 1. **Be Accurate**: When displaying Kody Rules, ensure that the information is accurate and reflects the current state of the rules as retrieved from the system.

--- a/skills/kodus-kody-rules/rules/create-kody-rule.md
+++ b/skills/kodus-kody-rules/rules/create-kody-rule.md
@@ -29,6 +29,12 @@ kodus rules create --title <title> --rule <rule-content> [--repo-id <repository-
 
 6. **Communicate the new Kody Rule**: Inform the user about the new Kody Rule and how it will be applied in future code generation.
 
+## Centralized Config Behavior
+
+When centralized config is enabled, creating a rule may return centralized PR metadata instead of a direct rule record.
+
+In this case, report PR details and clearly explain the rule will only apply after PR merge and sync.
+
 ## Guidelines for Creating a Kody Rule
 
 1. **Identify the Purpose**: Clearly define what the Kody Rule is intended to achieve. Is it meant to enforce a coding style, ensure best practices, or address a specific use case?

--- a/skills/kodus-kody-rules/rules/update-kody-rule.md
+++ b/skills/kodus-kody-rules/rules/update-kody-rule.md
@@ -36,6 +36,12 @@ kodus rules update --uuid <uuid> [--repo-id <repository-id>] [--title <title>] [
 
 8. **Communicate the updated Kody Rule**: Inform the user about the updated Kody Rule and how the changes will affect future code generation.
 
+## Centralized Config Behavior
+
+When centralized config is enabled, updating a rule may return centralized PR metadata instead of an immediate rule update.
+
+In this case, report PR details and clarify the update is pending until PR merge and sync.
+
 ## Guidelines for Updating a Kody Rule
 
 1. **Identify the Changes**: Clearly define what changes are being made to the existing Kody Rule. Are you modifying the rule's behavior, scope, severity, or other attributes?

--- a/skills/kodus-kody-rules/rules/view-kody-rules.md
+++ b/skills/kodus-kody-rules/rules/view-kody-rules.md
@@ -39,6 +39,12 @@ Do not alter the content of the rules; display them as they are retrieved to ens
 
 5. **Answer Follow-up Questions**: Be prepared to answer any follow-up questions the user may have about the Kody Rules, such as how to create or update rules, or how specific rules affect code generation.
 
+## Centralized Config Context
+
+When centralized config is enabled, rules may include centralized pending state metadata.
+
+When relevant, surface centralized path and status, and clarify that pending centralized changes apply only after PR merge and sync.
+
 ## Guidelines for Viewing Kody Rules
 
 1. **Be Accurate**: When displaying Kody Rules, ensure that the information is accurate and reflects the current state of the rules as retrieved from the system.

--- a/src/commands/__tests__/rules.test.ts
+++ b/src/commands/__tests__/rules.test.ts
@@ -85,6 +85,31 @@ describe('rules command actions', () => {
         );
     });
 
+    it('prints centralized PR information when create returns centralized-pr mode', async () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        mockRulesService.createRule.mockResolvedValue({
+            mode: 'centralized-pr',
+            prUrl: 'https://example.com/pr/123',
+            prNumber: 123,
+            message: 'Queued in active centralized PR.',
+        } as any);
+
+        await rulesCreateAction({
+            title: 'Use async/await',
+            rule: 'Prefer async/await',
+            repoId: 'global',
+        });
+
+        const output = logSpy.mock.calls
+            .map((call) => call.join(' '))
+            .join('\n');
+        expect(output).toContain(
+            'Kody Rule change proposed through centralized pull request.',
+        );
+        expect(output).toContain('PR URL: https://example.com/pr/123');
+        expect(output).toContain('PR Number: 123');
+    });
+
     it('converts service errors to CLI exits', async () => {
         const errorSpy = vi
             .spyOn(console, 'error')

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -9,6 +9,7 @@ import type {
 import { exitWithCode } from '../utils/cli-exit.js';
 import { normalizeCommandError } from '../utils/command-errors.js';
 import { cliError, cliInfo } from '../utils/logger.js';
+import { isCentralizedPrResponse as isCentralizedPrResponseTypeGuard } from '../types/rules.js';
 
 export type RulesCreateOptions = {
     title: string;
@@ -88,6 +89,24 @@ export async function rulesCreateAction(
             return;
         }
 
+        if (isCentralizedPrResponseTypeGuard(createdRule)) {
+            cliInfo(
+                chalk.green(
+                    'Kody Rule change proposed through centralized pull request.',
+                ),
+            );
+            if (createdRule.message) {
+                cliInfo(createdRule.message);
+            }
+            if (createdRule.prUrl) {
+                cliInfo(`PR URL: ${createdRule.prUrl}`);
+            }
+            if (createdRule.prNumber !== undefined) {
+                cliInfo(`PR Number: ${createdRule.prNumber}`);
+            }
+            return;
+        }
+
         cliInfo(chalk.green('Kody Rule created successfully.'));
         printRule(createdRule, options.repoId ?? 'global');
     } catch (error) {
@@ -113,6 +132,24 @@ export async function rulesUpdateAction(
 
         if (options.json) {
             cliInfo(JSON.stringify(updatedRule, null, 2));
+            return;
+        }
+
+        if (isCentralizedPrResponseTypeGuard(updatedRule)) {
+            cliInfo(
+                chalk.green(
+                    'Kody Rule change proposed through centralized pull request.',
+                ),
+            );
+            if (updatedRule.message) {
+                cliInfo(updatedRule.message);
+            }
+            if (updatedRule.prUrl) {
+                cliInfo(`PR URL: ${updatedRule.prUrl}`);
+            }
+            if (updatedRule.prNumber !== undefined) {
+                cliInfo(`PR Number: ${updatedRule.prNumber}`);
+            }
             return;
         }
 

--- a/src/features/repo-config/actions.ts
+++ b/src/features/repo-config/actions.ts
@@ -7,7 +7,10 @@ import {
     formatRepositorySetupPreview,
 } from '../../formatters/repo-config.js';
 import { repoConfigService } from '../../services/repo-config.service.js';
-import { repositorySettingsService } from '../../services/repo-settings.service.js';
+import {
+    repositorySettingsService,
+    type RepositorySettingsMutationResult,
+} from '../../services/repo-settings.service.js';
 import { repositorySettingsWizardService } from '../../services/repo-settings-wizard.service.js';
 import { exitWithCode } from '../../utils/cli-exit.js';
 import { cliError, cliInfo } from '../../utils/logger.js';
@@ -63,13 +66,29 @@ function shouldOfferSetupPrompt(options: ConfigRepoAddOptions = {}): boolean {
 }
 
 function printRepositoryMutationResult(
-    result: Awaited<
-        ReturnType<typeof repositorySettingsService.updateRepositorySettings>
-    >,
+    result: RepositorySettingsMutationResult,
     options: ConfigRepoMutationOptions = {},
 ): void {
     if (options.json) {
         cliInfo(JSON.stringify(result, null, 2));
+        return;
+    }
+
+    if ('centralized' in result) {
+        cliInfo(
+            chalk.green(
+                `Repository settings change proposed for ${result.repositoryFullName}`,
+            ),
+        );
+        cliInfo(
+            result.centralized.message ||
+                'Centralized config is enabled. Change queued in a pull request.',
+        );
+
+        if (result.centralized.prUrl) {
+            cliInfo(`Pull request: ${result.centralized.prUrl}`);
+        }
+
         return;
     }
 
@@ -207,13 +226,14 @@ export async function configRepoSetupAction(
     try {
         const current =
             await repositorySettingsService.getRepositorySettings(repository);
-        let nextSettings = await repositorySettingsWizardService.collectSettings(
-            current.settings,
-            {
-                yes: options.yes,
-                writeLine: options.json ? undefined : cliInfo,
-            },
-        );
+        let nextSettings =
+            await repositorySettingsWizardService.collectSettings(
+                current.settings,
+                {
+                    yes: options.yes,
+                    writeLine: options.json ? undefined : cliInfo,
+                },
+            );
 
         while (true) {
             if (!options.json) {
@@ -301,7 +321,9 @@ export async function configRepoSetupAction(
                         currentSettings: current.settings,
                         nextSettings,
                         applied: true,
-                        settings: updated.settings,
+                        ...('settings' in updated
+                            ? { settings: updated.settings }
+                            : { centralized: updated.centralized }),
                     },
                     null,
                     2,
@@ -310,11 +332,7 @@ export async function configRepoSetupAction(
             return;
         }
 
-        cliInfo(
-            chalk.green(
-                `Repository settings updated for ${updated.repositoryFullName}`,
-            ),
-        );
+        printRepositoryMutationResult(updated, options);
     } catch (error) {
         if (error instanceof Error && error.message.includes('force closed')) {
             cliInfo(chalk.yellow('Operation cancelled'));

--- a/src/services/__tests__/repo-settings.service.test.ts
+++ b/src/services/__tests__/repo-settings.service.test.ts
@@ -213,18 +213,55 @@ describe('repositorySettingsService.updateRepositorySettings', () => {
         mockAuthService.getValidToken.mockResolvedValue('eyJ.test.token');
 
         await expect(
-            repositorySettingsService.updateRepositorySettings('kodustech/cli', {
-                reviewEnabled: false,
-                autoApproveEnabled: true,
-                requestChangesMinSeverity: 'high',
-                ignoredFilePatterns: ['dist/**'],
-                baseBranchPatterns: ['main', 'release/*'],
-                ignoredTitlePatterns: ['draft*'],
-            }),
+            repositorySettingsService.updateRepositorySettings(
+                'kodustech/cli',
+                {
+                    reviewEnabled: false,
+                    autoApproveEnabled: true,
+                    requestChangesMinSeverity: 'high',
+                    ignoredFilePatterns: ['dist/**'],
+                    baseBranchPatterns: ['main', 'release/*'],
+                    ignoredTitlePatterns: ['draft*'],
+                },
+            ),
         ).rejects.toEqual(
             expect.objectContaining<Partial<CommandError>>({
                 code: 'AUTH_REQUIRED',
             }),
         );
+    });
+
+    it('returns centralized PR metadata when backend routes repository settings update through centralized config PR flow', async () => {
+        mockApiConfig.updateRepositorySettings = vi.fn().mockResolvedValue({
+            mode: 'centralized-pr',
+            pending: true,
+            message:
+                'Centralized config is enabled. Code review settings change proposed through a pull request.',
+            prUrl: 'https://github.com/kodustech/config-repo/pull/123',
+        } as any);
+
+        const result = await repositorySettingsService.updateRepositorySettings(
+            'kodustech/cli',
+            {
+                reviewEnabled: true,
+                autoApproveEnabled: true,
+                requestChangesMinSeverity: 'medium',
+                ignoredFilePatterns: ['dist/**'],
+                baseBranchPatterns: ['main', 'release/*'],
+                ignoredTitlePatterns: ['wip*'],
+            },
+        );
+
+        expect(result).toEqual({
+            repositoryId: 'repo-1',
+            repositoryFullName: 'kodustech/cli',
+            centralized: {
+                mode: 'centralized-pr',
+                pending: true,
+                message:
+                    'Centralized config is enabled. Code review settings change proposed through a pull request.',
+                prUrl: 'https://github.com/kodustech/config-repo/pull/123',
+            },
+        });
     });
 });

--- a/src/services/__tests__/rules.service.test.ts
+++ b/src/services/__tests__/rules.service.test.ts
@@ -83,6 +83,24 @@ describe('rulesService', () => {
         });
     });
 
+    it('passes through centralized PR response on create', async () => {
+        mockRulesApi.createRule.mockResolvedValue({
+            mode: 'centralized-pr',
+            prUrl: 'https://example.com/pr/1',
+            pending: true,
+        } as any);
+
+        const result = await rulesService.createRule({
+            title: 'Use strict equals',
+            rule: 'Prefer === and !==',
+            repositoryId: 'repo-1',
+        });
+
+        expect(result).toEqual(
+            expect.objectContaining({ mode: 'centralized-pr' }),
+        );
+    });
+
     it('validates severity values', async () => {
         await expect(
             rulesService.createRule({

--- a/src/services/api/__tests__/rules.api.test.ts
+++ b/src/services/api/__tests__/rules.api.test.ts
@@ -69,6 +69,28 @@ describe('RealRulesApi', () => {
         );
     });
 
+    it('supports centralized PR response payload for create', async () => {
+        const requestWithRetry = vi.fn().mockResolvedValue({
+            mode: 'centralized-pr',
+            prUrl: 'https://example.com/pr/88',
+            pending: true,
+        });
+
+        const api = new RealRulesApi(requestWithRetry);
+        const result = await api.createRule('kodus_team_key', {
+            title: 'Use async/await',
+            rule: 'Prefer async/await over raw promises',
+            repositoryId: 'repo-1',
+            severity: 'high',
+            scope: 'file',
+            path: '**/*.ts',
+        });
+
+        expect(result).toEqual(
+            expect.objectContaining({ mode: 'centralized-pr' }),
+        );
+    });
+
     it('views rules by filters', async () => {
         const requestWithRetry = vi.fn().mockResolvedValue([]);
 

--- a/src/services/api/api.interface.ts
+++ b/src/services/api/api.interface.ts
@@ -1,6 +1,7 @@
 import type { AuthResponse, UserInfo } from '../../types/auth.js';
 import type {
     CentralizedConfigActionResponse,
+    CentralizedPrMetadata,
     CentralizedConfigStatus,
     CodeReviewParameter,
     ConfigAddRepositoriesResponse,
@@ -124,7 +125,7 @@ export interface IConfigApi {
         accessToken: string,
         repositoryId: string,
         settings: RepositorySettings,
-    ): Promise<RepositorySettings>;
+    ): Promise<RepositorySettings | CentralizedPrMetadata>;
     getCentralizedConfigStatus(
         accessToken: string,
     ): Promise<CentralizedConfigStatus>;

--- a/src/services/api/api.interface.ts
+++ b/src/services/api/api.interface.ts
@@ -22,6 +22,7 @@ import type {
 import type {
     CreateKodyRuleRequest,
     KodyRule,
+    KodyRuleMutationResult,
     UpdateKodyRuleRequest,
     ViewKodyRulesRequest,
 } from '../../types/rules.js';
@@ -151,12 +152,12 @@ export interface IRulesApi {
     createRule(
         accessToken: string,
         payload: CreateKodyRuleRequest,
-    ): Promise<KodyRule>;
+    ): Promise<KodyRuleMutationResult>;
     updateRule(
         accessToken: string,
         ruleId: string,
         payload: UpdateKodyRuleRequest,
-    ): Promise<KodyRule>;
+    ): Promise<KodyRuleMutationResult>;
     viewRules(
         accessToken: string,
         query?: ViewKodyRulesRequest,

--- a/src/services/api/config.api.ts
+++ b/src/services/api/config.api.ts
@@ -1,5 +1,6 @@
 import type {
     CentralizedConfigActionResponse,
+    CentralizedPrMetadata,
     CentralizedConfigStatus,
     CodeReviewParameter,
     ConfigAddRepositoriesResponse,
@@ -140,8 +141,8 @@ export class RealConfigApi implements IConfigApi {
         accessToken: string,
         repositoryId: string,
         settings: RepositorySettings,
-    ): Promise<RepositorySettings> {
-        return this.requester<RepositorySettings>(
+    ): Promise<RepositorySettings | CentralizedPrMetadata> {
+        return this.requester<RepositorySettings | CentralizedPrMetadata>(
             `/cli/config/repositories/${encodeURIComponent(repositoryId)}/settings`,
             {
                 method: 'PATCH',

--- a/src/services/api/rules.api.ts
+++ b/src/services/api/rules.api.ts
@@ -1,4 +1,5 @@
 import type {
+    KodyRuleMutationResult,
     CreateKodyRuleRequest,
     KodyRule,
     UpdateKodyRuleRequest,
@@ -26,8 +27,8 @@ export class RealRulesApi implements IRulesApi {
     async createRule(
         accessToken: string,
         payload: CreateKodyRuleRequest,
-    ): Promise<KodyRule> {
-        return this.requester<KodyRule>('/cli/kody-rules', {
+    ): Promise<KodyRuleMutationResult> {
+        return this.requester<KodyRuleMutationResult>('/cli/kody-rules', {
             method: 'POST',
             headers: this.buildAuthHeaders(accessToken),
             body: JSON.stringify(payload),
@@ -38,8 +39,8 @@ export class RealRulesApi implements IRulesApi {
         accessToken: string,
         ruleId: string,
         payload: UpdateKodyRuleRequest,
-    ): Promise<KodyRule> {
-        return this.requester<KodyRule>(
+    ): Promise<KodyRuleMutationResult> {
+        return this.requester<KodyRuleMutationResult>(
             `/cli/kody-rules/${encodeURIComponent(ruleId)}`,
             {
                 method: 'PATCH',

--- a/src/services/repo-settings.service.ts
+++ b/src/services/repo-settings.service.ts
@@ -2,6 +2,7 @@ import { api } from './api/index.js';
 import { authService } from './auth.service.js';
 import { gitService } from './git.service.js';
 import type { ConfigRepository } from '../types/config.js';
+import type { CentralizedPrMetadata } from '../types/config.js';
 import type { RepositorySettings } from '../types/repo-config.js';
 import { CommandError } from '../utils/command-errors.js';
 
@@ -10,6 +11,16 @@ export type RepositorySettingsResult = {
     repositoryFullName: string;
     settings: RepositorySettings;
 };
+
+export type RepositorySettingsCentralizedPrResult = {
+    repositoryId: string;
+    repositoryFullName: string;
+    centralized: CentralizedPrMetadata & { mode: 'centralized-pr' };
+};
+
+export type RepositorySettingsMutationResult =
+    | RepositorySettingsResult
+    | RepositorySettingsCentralizedPrResult;
 
 class RepositorySettingsService {
     async getRepositorySettings(
@@ -22,7 +33,7 @@ class RepositorySettingsService {
     async updateRepositorySettings(
         target: string,
         settings: RepositorySettings,
-    ): Promise<RepositorySettingsResult> {
+    ): Promise<RepositorySettingsMutationResult> {
         const teamKey = await this.requireTeamKey();
         return this.updateRepositorySettingsWithTeamKey(
             target,
@@ -38,9 +49,8 @@ class RepositorySettingsService {
         matchedRepository: ConfigRepository;
     }> {
         const repositoryRef = await this.resolveRepositoryReference(target);
-        const repositories = await api.config.getSelectedRepositories(
-            accessToken,
-        );
+        const repositories =
+            await api.config.getSelectedRepositories(accessToken);
         const matchedRepository = this.findRepositoryMatch(
             repositoryRef,
             repositories,
@@ -95,7 +105,7 @@ class RepositorySettingsService {
         target: string,
         teamKey: string,
         settings: RepositorySettings,
-    ): Promise<RepositorySettingsResult> {
+    ): Promise<RepositorySettingsMutationResult> {
         const { matchedRepository } = await this.resolveConfiguredRepository(
             target,
             teamKey,
@@ -105,6 +115,15 @@ class RepositorySettingsService {
             matchedRepository.id,
             settings,
         );
+
+        if (this.isCentralizedPrMetadata(updatedSettings)) {
+            return {
+                repositoryId: matchedRepository.id,
+                repositoryFullName:
+                    this.toRepositoryFullName(matchedRepository),
+                centralized: updatedSettings,
+            };
+        }
 
         return {
             repositoryId: matchedRepository.id,
@@ -168,6 +187,17 @@ class RepositorySettingsService {
         return (
             repository.full_name ||
             `${repository.organizationName}/${repository.name}`
+        );
+    }
+
+    private isCentralizedPrMetadata(
+        value: RepositorySettings | CentralizedPrMetadata,
+    ): value is CentralizedPrMetadata & { mode: 'centralized-pr' } {
+        return (
+            typeof value === 'object' &&
+            value !== null &&
+            'mode' in value &&
+            (value as { mode?: string }).mode === 'centralized-pr'
         );
     }
 }

--- a/src/services/rules.service.ts
+++ b/src/services/rules.service.ts
@@ -1,4 +1,5 @@
 import type {
+    KodyRuleMutationResult,
     CreateKodyRuleRequest,
     KodyRule,
     KodyRuleScope,
@@ -24,7 +25,9 @@ const VALID_SEVERITIES: KodyRuleSeverity[] = [
 const VALID_SCOPES: KodyRuleScope[] = ['pull request', 'file'];
 
 class RulesService {
-    async createRule(input: CreateKodyRuleRequest): Promise<KodyRule> {
+    async createRule(
+        input: CreateKodyRuleRequest,
+    ): Promise<KodyRuleMutationResult> {
         const accessToken = await authService.getValidToken();
         const payload: CreateKodyRuleRequest = {
             title: this.requireText(input.title, 'title'),
@@ -39,7 +42,9 @@ class RulesService {
         return api.rules.createRule(accessToken, payload);
     }
 
-    async updateRule(input: UpdateKodyRuleInput): Promise<KodyRule> {
+    async updateRule(
+        input: UpdateKodyRuleInput,
+    ): Promise<KodyRuleMutationResult> {
         const accessToken = await authService.getValidToken();
         const ruleId = this.requireText(input.ruleId, 'rule-id');
         let hasRuleChanges = false;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -64,3 +64,12 @@ export interface CentralizedConfigActionResponse {
     message: string;
     prUrl?: string;
 }
+
+export interface CentralizedPrMetadata {
+    mode: 'direct' | 'centralized-pr';
+    prUrl?: string;
+    prNumber?: number;
+    reused?: boolean;
+    pending?: boolean;
+    message?: string;
+}

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -12,6 +12,27 @@ export interface KodyRule {
     path?: string;
 }
 
+export interface CentralizedPrResponse {
+    mode: 'centralized-pr';
+    prUrl?: string;
+    prNumber?: number;
+    reused?: boolean;
+    pending?: boolean;
+    message?: string;
+}
+
+export type KodyRuleMutationResult = KodyRule | CentralizedPrResponse;
+
+export const isCentralizedPrResponse = (
+    value: unknown,
+): value is CentralizedPrResponse => {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    return (value as { mode?: string }).mode === 'centralized-pr';
+};
+
 export interface CreateKodyRuleRequest {
     title: string;
     rule: string;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces support for a centralized configuration workflow within the Kodus CLI, specifically for managing Kody Rules and repository settings.

Key changes include:

*   **Centralized PR Handling**: The CLI now recognizes and processes responses indicating that Kody Rule creations, updates, and repository settings changes are proposed via a centralized pull request (PR) rather than being applied directly.
*   **User Communication**: When a change is routed through a centralized PR, the CLI will inform the user that the change is pending, provide the PR URL and number, and clarify that the update will only take effect after the PR is merged and synced.
*   **Kody Rule Context**: For viewing Kody Rules, the CLI can now display additional centralized configuration context, such as the centralized path and status (e.g., `pending_add`, `pending_edit`, `pending_delete`, `synced`).
*   **API and Service Layer Updates**: The underlying API interfaces, service methods, and data types have been updated to accommodate the new `centralized-pr` response mode, allowing the system to differentiate between direct changes and those requiring PR approval.
*   **Documentation and AI Guidance**: The `kodus-kody-rules` skill documentation has been updated with new sections on "Centralized Config Convention" and "Centralized Config Behavior" to guide the AI on how to interpret and communicate these new workflows to users.
*   **Unit Tests**: New unit tests have been added to ensure the CLI and services correctly handle and display centralized PR responses for both Kody Rules and repository settings.

This enhancement enables a more governed and auditable process for managing configurations, where changes are reviewed and approved through a pull request mechanism.
<!-- kody-pr-summary:end -->