### PR TITLE
fix(review): unblock large-branch CLI reviews (undici timeouts, 60 min default, skip inline)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "open": "^11.0.0",
         "ora": "^9.3.0",
         "simple-git": "^3.33.0",
+        "undici": "^8.0.2",
         "update-notifier": "^7.3.1",
         "yaml": "^2.8.2"
     },

--- a/src/services/__tests__/review-config-builder.test.ts
+++ b/src/services/__tests__/review-config-builder.test.ts
@@ -30,7 +30,7 @@ describe('buildReviewConfig', () => {
         expect(filterFiles).not.toHaveBeenCalled();
     });
 
-    it('loads and filters files when fast mode is disabled', async () => {
+    it('loads and filters files for working-tree reviews (no branch/commit)', async () => {
         const files: FileContent[] = [
             {
                 path: 'src/a.ts',
@@ -49,8 +49,6 @@ describe('buildReviewConfig', () => {
                 options: {
                     files: ['src/a.ts'],
                     staged: true,
-                    commit: 'abc123',
-                    branch: 'main',
                     quiet: true,
                 },
                 getFullFileContents,
@@ -64,9 +62,59 @@ describe('buildReviewConfig', () => {
 
         expect(getFullFileContents).toHaveBeenCalledWith(['src/a.ts'], {
             staged: true,
-            commit: 'abc123',
-            branch: 'main',
+            commit: undefined,
+            branch: undefined,
         });
         expect(filterFiles).toHaveBeenCalledWith(files, true);
+    });
+
+    it('skips inlining when comparing against a branch', async () => {
+        // Branch mode: the diff is against committed history, so the backend
+        // can clone the same commit into its sandbox and read files from
+        // there. Inlining them would duplicate the content for no benefit
+        // and can blow past the backend's body-parser limit on large PRs.
+        const getFullFileContents = vi.fn();
+        const filterFiles = vi.fn();
+
+        await expect(
+            buildReviewConfig({
+                rulesOnly: false,
+                fast: false,
+                options: {
+                    branch: 'main',
+                },
+                getFullFileContents,
+                filterFiles,
+            }),
+        ).resolves.toEqual({
+            rulesOnly: false,
+            fast: false,
+        });
+
+        expect(getFullFileContents).not.toHaveBeenCalled();
+        expect(filterFiles).not.toHaveBeenCalled();
+    });
+
+    it('skips inlining when comparing a specific commit', async () => {
+        const getFullFileContents = vi.fn();
+        const filterFiles = vi.fn();
+
+        await expect(
+            buildReviewConfig({
+                rulesOnly: false,
+                fast: false,
+                options: {
+                    commit: 'abc123',
+                },
+                getFullFileContents,
+                filterFiles,
+            }),
+        ).resolves.toEqual({
+            rulesOnly: false,
+            fast: false,
+        });
+
+        expect(getFullFileContents).not.toHaveBeenCalled();
+        expect(filterFiles).not.toHaveBeenCalled();
     });
 });

--- a/src/services/api/__tests__/api.real.test.ts
+++ b/src/services/api/__tests__/api.real.test.ts
@@ -10,6 +10,19 @@ const configMocks = vi.hoisted(() => ({
     loadConfig: vi.fn(),
 }));
 
+// api-core.ts now uses undici's fetch (not Node's global) so the custom
+// long-lived Agent is actually honored. Tests must mock the undici module.
+const undiciMocks = vi.hoisted(() => ({
+    fetch: vi.fn(),
+}));
+
+vi.mock('undici', () => ({
+    Agent: class MockAgent {
+        constructor(_opts?: unknown) {}
+    },
+    fetch: undiciMocks.fetch,
+}));
+
 vi.mock('../../../utils/device.js', () => ({
     getDeviceIdentity: deviceMocks.getDeviceIdentity,
     updateDeviceToken: deviceMocks.updateDeviceToken,
@@ -27,8 +40,8 @@ describe('RealApi request headers', () => {
     beforeEach(() => {
         _resetConfigCache();
         configMocks.loadConfig.mockResolvedValue(null);
-        fetchMock = vi.fn();
-        vi.stubGlobal('fetch', fetchMock as any);
+        fetchMock = undiciMocks.fetch;
+        fetchMock.mockReset();
         deviceMocks.getDeviceIdentity.mockResolvedValue({
             deviceId: '11111111-1111-4111-8111-111111111111',
             deviceToken: 'device-token-123',
@@ -160,8 +173,8 @@ describe('RealApi review.getPullRequestSuggestions', () => {
     beforeEach(() => {
         _resetConfigCache();
         configMocks.loadConfig.mockResolvedValue(null);
-        fetchMock = vi.fn();
-        vi.stubGlobal('fetch', fetchMock as any);
+        fetchMock = undiciMocks.fetch;
+        fetchMock.mockReset();
         deviceMocks.getDeviceIdentity.mockResolvedValue({
             deviceId: '11111111-1111-4111-8111-111111111111',
         });
@@ -270,8 +283,8 @@ describe('RealApi config repository methods', () => {
     beforeEach(() => {
         _resetConfigCache();
         configMocks.loadConfig.mockResolvedValue(null);
-        fetchMock = vi.fn();
-        vi.stubGlobal('fetch', fetchMock as any);
+        fetchMock = undiciMocks.fetch;
+        fetchMock.mockReset();
         deviceMocks.getDeviceIdentity.mockResolvedValue({
             deviceId: '11111111-1111-4111-8111-111111111111',
         });
@@ -714,8 +727,8 @@ describe('RealApi review.analyze auth mode', () => {
     beforeEach(() => {
         _resetConfigCache();
         configMocks.loadConfig.mockResolvedValue(null);
-        fetchMock = vi.fn();
-        vi.stubGlobal('fetch', fetchMock as any);
+        fetchMock = undiciMocks.fetch;
+        fetchMock.mockReset();
         deviceMocks.getDeviceIdentity.mockResolvedValue({
             deviceId: '11111111-1111-4111-8111-111111111111',
         });
@@ -765,8 +778,8 @@ describe('Cloudflare Access headers from config', () => {
     beforeEach(() => {
         _resetConfigCache();
         configMocks.loadConfig.mockResolvedValue(null);
-        fetchMock = vi.fn();
-        vi.stubGlobal('fetch', fetchMock as any);
+        fetchMock = undiciMocks.fetch;
+        fetchMock.mockReset();
         deviceMocks.getDeviceIdentity.mockResolvedValue({
             deviceId: '11111111-1111-4111-8111-111111111111',
         });
@@ -881,8 +894,8 @@ describe('API base URL from config', () => {
     beforeEach(() => {
         _resetConfigCache();
         configMocks.loadConfig.mockResolvedValue(null);
-        fetchMock = vi.fn();
-        vi.stubGlobal('fetch', fetchMock as any);
+        fetchMock = undiciMocks.fetch;
+        fetchMock.mockReset();
         deviceMocks.getDeviceIdentity.mockResolvedValue({
             deviceId: '11111111-1111-4111-8111-111111111111',
         });

--- a/src/services/api/api-core.ts
+++ b/src/services/api/api-core.ts
@@ -1,3 +1,4 @@
+import { Agent, fetch as undiciFetch } from 'undici';
 import { ApiError } from '../../types/errors.js';
 import { loadConfig, type CliConfig } from '../../utils/config.js';
 import { getDeviceIdentity, updateDeviceToken } from '../../utils/device.js';
@@ -74,7 +75,37 @@ export async function resolveApiBaseUrl(): Promise<string> {
     return defaultUrl;
 }
 
-const REQUEST_TIMEOUT_MS = 20 * 60 * 1000;
+// Default 60 minutes — covers large branch reviews that split into many
+// agent batches (e.g. ~6 batches × 5 min each). Overridable via
+// KODUS_REQUEST_TIMEOUT_MIN (in minutes) for extreme cases.
+const DEFAULT_REQUEST_TIMEOUT_MIN = 60;
+const parsedTimeoutMin = Number.parseInt(
+    process.env.KODUS_REQUEST_TIMEOUT_MIN ?? '',
+    10,
+);
+const REQUEST_TIMEOUT_MIN =
+    Number.isFinite(parsedTimeoutMin) && parsedTimeoutMin > 0
+        ? parsedTimeoutMin
+        : DEFAULT_REQUEST_TIMEOUT_MIN;
+const REQUEST_TIMEOUT_MS = REQUEST_TIMEOUT_MIN * 60 * 1000;
+
+// Undici (the HTTP client used by Node's global fetch) defaults both
+// headersTimeout and bodyTimeout to 5 minutes. Long CLI reviews of large
+// branches easily exceed that, the client silently aborts, and the retry
+// wrapper fires a new request — causing a retry storm where the backend
+// processes the same review multiple times in parallel.
+//
+// We use undici's own fetch (imported from the installed undici package)
+// with a dispatcher whose timeouts match REQUEST_TIMEOUT_MS. Passing a
+// dispatcher to Node's global fetch does NOT work reliably: Node's bundled
+// undici is a different module instance than the one installed here, so
+// the Agent we create is not honored by the global fetch.
+const longLivedDispatcher = new Agent({
+    headersTimeout: REQUEST_TIMEOUT_MS,
+    bodyTimeout: REQUEST_TIMEOUT_MS,
+    keepAliveTimeout: REQUEST_TIMEOUT_MS,
+    keepAliveMaxTimeout: REQUEST_TIMEOUT_MS,
+});
 
 /**
  * Returns Cloudflare Access headers when configured.
@@ -238,9 +269,10 @@ export async function request<T>(
 
     let response: Response;
     try {
-        response = await fetch(url, {
+        const undiciOptions: any = {
             ...options,
             signal: controller.signal,
+            dispatcher: longLivedDispatcher,
             headers: {
                 'Content-Type': 'application/json',
                 ...cfHeaders,
@@ -252,7 +284,11 @@ export async function request<T>(
                     : {}),
                 ...options.headers,
             },
-        });
+        };
+        response = (await undiciFetch(
+            url,
+            undiciOptions,
+        )) as unknown as Response;
     } catch (error) {
         clearTimeout(timeout);
         if (error instanceof DOMException && error.name === 'AbortError') {
@@ -379,9 +415,10 @@ export async function requestBinary(
 
     let response: Response;
     try {
-        response = await fetch(url, {
+        const undiciOptions: any = {
             ...options,
             signal: controller.signal,
+            dispatcher: longLivedDispatcher,
             headers: {
                 ...cfHeaders,
                 ...(deviceIdentity?.deviceId
@@ -392,7 +429,11 @@ export async function requestBinary(
                     : {}),
                 ...options.headers,
             },
-        });
+        };
+        response = (await undiciFetch(
+            url,
+            undiciOptions,
+        )) as unknown as Response;
     } catch (error) {
         clearTimeout(timeout);
         if (error instanceof DOMException && error.name === 'AbortError') {

--- a/src/services/api/api.interface.ts
+++ b/src/services/api/api.interface.ts
@@ -125,7 +125,9 @@ export interface IConfigApi {
         accessToken: string,
         repositoryId: string,
         settings: RepositorySettings,
-    ): Promise<RepositorySettings | CentralizedPrMetadata>;
+    ): Promise<
+        RepositorySettings | (CentralizedPrMetadata & { mode: 'centralized-pr' })
+    >;
     getCentralizedConfigStatus(
         accessToken: string,
     ): Promise<CentralizedConfigStatus>;

--- a/src/services/api/config.api.ts
+++ b/src/services/api/config.api.ts
@@ -141,8 +141,12 @@ export class RealConfigApi implements IConfigApi {
         accessToken: string,
         repositoryId: string,
         settings: RepositorySettings,
-    ): Promise<RepositorySettings | CentralizedPrMetadata> {
-        return this.requester<RepositorySettings | CentralizedPrMetadata>(
+    ): Promise<
+        RepositorySettings | (CentralizedPrMetadata & { mode: 'centralized-pr' })
+    > {
+        return this.requester<
+            RepositorySettings | (CentralizedPrMetadata & { mode: 'centralized-pr' })
+        >(
             `/cli/config/repositories/${encodeURIComponent(repositoryId)}/settings`,
             {
                 method: 'PATCH',

--- a/src/services/repo-settings.service.ts
+++ b/src/services/repo-settings.service.ts
@@ -128,7 +128,7 @@ class RepositorySettingsService {
         return {
             repositoryId: matchedRepository.id,
             repositoryFullName: this.toRepositoryFullName(matchedRepository),
-            settings: updatedSettings as RepositorySettings,
+            settings: updatedSettings,
         };
     }
 
@@ -191,7 +191,9 @@ class RepositorySettingsService {
     }
 
     private isCentralizedPrMetadata(
-        value: RepositorySettings | CentralizedPrMetadata,
+        value:
+            | RepositorySettings
+            | (CentralizedPrMetadata & { mode: 'centralized-pr' }),
     ): value is CentralizedPrMetadata & { mode: 'centralized-pr' } {
         return (
             typeof value === 'object' &&

--- a/src/services/repo-settings.service.ts
+++ b/src/services/repo-settings.service.ts
@@ -128,7 +128,7 @@ class RepositorySettingsService {
         return {
             repositoryId: matchedRepository.id,
             repositoryFullName: this.toRepositoryFullName(matchedRepository),
-            settings: updatedSettings,
+            settings: updatedSettings as RepositorySettings,
         };
     }
 

--- a/src/services/review-config-builder.ts
+++ b/src/services/review-config-builder.ts
@@ -31,7 +31,19 @@ export async function buildReviewConfig({
         fast,
     };
 
-    if (fast) {
+    // Skip inlining file contents when:
+    //   - fast mode: the server runs with a capped step budget; the full
+    //     file bodies are extra payload with diminishing returns.
+    //   - branch / commit mode: the diff is computed against committed
+    //     history, so the backend can clone the same commit into its
+    //     sandbox and read files from there (via readFile/grep). Sending
+    //     20+ MB of inlined content per request on large refactors blew
+    //     past the backend's body parser limit for no benefit.
+    //
+    // Working-tree reviews (default and --staged) still inline files, since
+    // local WIP changes don't exist on any remote the backend could clone.
+    const skipInlining = fast || !!options?.branch || !!options?.commit;
+    if (skipInlining) {
         return reviewConfig;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,6 +2030,11 @@ undici-types@~7.18.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
+undici@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-8.0.2.tgz#b3638a9cc5697cac8caa11307888886ac4c9c8ba"
+  integrity sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==
+
 unicorn-magic@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz"


### PR DESCRIPTION
## Summary

Three related fixes that unblock reviewing very large branches from the CLI (cherry-picked from `fix/cli-large-branch-reviews`):

- **Undici timeouts**: `api-core.ts` now uses `undici`'s own `fetch` with a custom `Agent` whose headers/body timeouts match `REQUEST_TIMEOUT_MS`. Node's global fetch uses a bundled undici instance that ignores a dispatcher passed externally, which was causing silent 5 min aborts and retry storms on long reviews. Main already had this fix in the old `api.real.ts`, but it was lost when the file was split into `api-core.ts`.
- **Default timeout 20 min → 60 min**, overridable via `KODUS_REQUEST_TIMEOUT_MIN`. A 700+ file branch can split into ~6 agent batches of ~5 min each, easily exceeding 20 min wall time.
- **Skip inlining file contents** when the diff is computed against a branch (`-b`) or a specific commit (`--commit`). These modes only look at committed history, so the backend can clone the same commit into its sandbox. Inlining duplicated 20+ MB per request for no benefit. Working-tree reviews (default and `--staged`) still inline files.

## Test plan

- [ ] `yarn test` — updated `api.real.test.ts` (hoisted `undici` mock instead of stubbing `globalThis.fetch`) and added skip-inline cases to `review-config-builder.test.ts`
- [ ] Run a review against a large branch (>500 files) end-to-end and confirm no retry storm and no body-parser limit error
- [ ] Run a working-tree review and confirm file contents are still inlined

## Notes

- Pre-existing TS error in `src/services/repo-settings.service.ts:131` is unrelated to this change — already present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
This pull request addresses issues that prevented successful CLI reviews of large branches by implementing the following changes:

1.  **Increased API Request Timeout**: The default API request timeout has been extended from 20 minutes to 60 minutes. This timeout is now also configurable via the `KODUS_REQUEST_TIMEOUT_MIN` environment variable, allowing for further adjustments in extreme cases.
2.  **Reliable Timeout Application with Undici**: The CLI now explicitly uses `undici.fetch` with a custom `undici.Agent` to ensure that the configured request timeouts (headers, body, keep-alive) are reliably applied. This prevents silent aborts and subsequent retry storms that could occur with Node's global `fetch` for long-running requests, particularly during large branch reviews.
3.  **Skipped File Content Inlining for Branch/Commit Reviews**: To prevent exceeding backend payload limits, the CLI will no longer inline the full file contents into the request payload when performing reviews against a specific branch (`--branch`) or commit (`--commit`). In these scenarios, the backend can clone the repository history and access files directly. File contents will continue to be inlined for working-tree reviews (default and `--staged`) where local changes are not yet committed.
4.  **Test Updates**: Corresponding unit tests have been updated to reflect the new timeout behavior and the conditional file inlining logic.
<!-- kody-pr-summary:end -->